### PR TITLE
Error handling - Bug fixes

### DIFF
--- a/src/main/java/seedu/calidr/commons/core/Messages.java
+++ b/src/main/java/seedu/calidr/commons/core/Messages.java
@@ -14,4 +14,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
 
+    public static final String MESSAGE_DATE_TIME_FORMAT = "Date-times should be of the format DD-MM-YYYY hhmm";
+
 }

--- a/src/main/java/seedu/calidr/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/calidr/logic/commands/EditTaskCommand.java
@@ -86,7 +86,8 @@ public class EditTaskCommand extends Command {
      * Creates and returns a {@code Person} with the details of {@code personToEdit}
      * edited with {@code editPersonDescriptor}.
      */
-    private static Task createEditedTask(Task taskToEdit, EditTaskDescriptor editTaskDescriptor) {
+    private static Task createEditedTask(Task taskToEdit, EditTaskDescriptor editTaskDescriptor)
+            throws CommandException {
         assert taskToEdit != null;
 
         if (taskToEdit instanceof ToDo) {
@@ -107,6 +108,11 @@ public class EditTaskCommand extends Command {
                     .orElse(eventToEdit.getEventDateTimes().from);
             LocalDateTime updatedToDateTime = editEventTaskDescriptor.getToDateTime()
                     .orElse(eventToEdit.getEventDateTimes().to);
+
+            if (!EventDateTimes.isValidEventDateTimes(updatedFromDateTime, updatedToDateTime)) {
+                throw new CommandException(EventDateTimes.MESSAGE_CONSTRAINTS);
+            }
+
             EventDateTimes updatedEventTimes = new EventDateTimes(updatedFromDateTime, updatedToDateTime);
 
             return new Event(updatedTitle, updatedEventTimes);

--- a/src/main/java/seedu/calidr/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/calidr/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.calidr.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.calidr.commons.core.Messages.MESSAGE_DATE_TIME_FORMAT;
 import static seedu.calidr.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
@@ -173,7 +174,7 @@ public class ParserUtil {
             return dateTime;
 
         } catch (DateTimeParseException e) {
-            throw new ParseException("Date-times should be of the format DD-MM-YYYY hhmm");
+            throw new ParseException(MESSAGE_DATE_TIME_FORMAT);
         }
     }
 
@@ -210,6 +211,10 @@ public class ParserUtil {
 
         LocalDateTime from = parseDateTime(trimmedFromDateTime);
         LocalDateTime to = parseDateTime(trimmedToDateTime);
+
+        if (!EventDateTimes.isValidEventDateTimes(from, to)) {
+            throw new ParseException(EventDateTimes.MESSAGE_CONSTRAINTS);
+        }
 
         return new EventDateTimes(from, to);
     }

--- a/src/main/java/seedu/calidr/model/task/params/EventDateTimes.java
+++ b/src/main/java/seedu/calidr/model/task/params/EventDateTimes.java
@@ -37,7 +37,7 @@ public class EventDateTimes {
      * Returns true if a particular set of START and END date-times
      * is valid.
      */
-    public boolean isValidEventDateTimes(LocalDateTime start, LocalDateTime end) {
+    public static boolean isValidEventDateTimes(LocalDateTime start, LocalDateTime end) {
         return end.isAfter(start);
     }
 


### PR DESCRIPTION
## Features of this PR

1. Fixed bugs in handling cases when _invalid_ start and end date-times (when the end date-time is before the start date-time) are given for an `Event` either while adding or editing.
   - Previously, an `Exception` was thrown and not being caught.