### PR TITLE
New Commands - Mark and Unmark Task

### DIFF
--- a/src/main/java/seedu/calidr/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/calidr/logic/commands/MarkTaskCommand.java
@@ -1,0 +1,45 @@
+package seedu.calidr.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.calidr.commons.core.Messages;
+import seedu.calidr.commons.core.index.Index;
+import seedu.calidr.logic.commands.exceptions.CommandException;
+import seedu.calidr.model.Model;
+import seedu.calidr.model.task.Task;
+
+public class MarkTaskCommand extends Command {
+    public static final String COMMAND_WORD = "mark";
+
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD + ": Marks a task in your task list as 'done'"
+                    + "Parameters: INDEX (must be a positive integer) "
+                    + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_MARK_TASK_SUCCESS = "Task marked as done: %1$s";
+    //    public static final String MESSAGE_MARK_TASK_FAILED =
+    private final Index index;
+
+    public MarkTaskCommand(Index index) {
+        requireNonNull(index);
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Task> readOnlyTaskList = model.getFilteredTaskList();
+
+        if (index.getZeroBased() >= readOnlyTaskList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Task taskToMark = readOnlyTaskList.get(index.getZeroBased());
+
+        model.markTask(taskToMark);
+        return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, taskToMark));
+    }
+
+}

--- a/src/main/java/seedu/calidr/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/calidr/logic/commands/MarkTaskCommand.java
@@ -14,12 +14,12 @@ public class MarkTaskCommand extends Command {
     public static final String COMMAND_WORD = "mark";
 
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Marks a task in your task list as 'done'"
+            COMMAND_WORD + ": Marks a task in your task list as 'done'\n"
                     + "Parameters: INDEX (must be a positive integer) "
                     + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_MARK_TASK_SUCCESS = "Task marked as done: %1$s";
-    
+
     private final Index index;
 
     public MarkTaskCommand(Index index) {

--- a/src/main/java/seedu/calidr/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/calidr/logic/commands/UnmarkTaskCommand.java
@@ -14,7 +14,7 @@ public class UnmarkTaskCommand extends Command {
     public static final String COMMAND_WORD = "unmark";
 
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Marks a task in your task list as 'not done'"
+            COMMAND_WORD + ": Marks a task in your task list as 'not done'\n"
                     + "Parameters: INDEX (must be a positive integer) "
                     + "Example: " + COMMAND_WORD + " 2";
 

--- a/src/main/java/seedu/calidr/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/calidr/logic/commands/UnmarkTaskCommand.java
@@ -10,19 +10,19 @@ import seedu.calidr.logic.commands.exceptions.CommandException;
 import seedu.calidr.model.Model;
 import seedu.calidr.model.task.Task;
 
-public class MarkTaskCommand extends Command {
-    public static final String COMMAND_WORD = "mark";
+public class UnmarkTaskCommand extends Command {
+    public static final String COMMAND_WORD = "unmark";
 
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Marks a task in your task list as 'done'"
+            COMMAND_WORD + ": Marks a task in your task list as 'not done'"
                     + "Parameters: INDEX (must be a positive integer) "
-                    + "Example: " + COMMAND_WORD + " 1";
+                    + "Example: " + COMMAND_WORD + " 2";
 
-    public static final String MESSAGE_MARK_TASK_SUCCESS = "Task marked as done: %1$s";
-    
+    public static final String MESSAGE_UNMARK_TASK_SUCCESS = "Task marked as not done: %1$s";
+
     private final Index index;
 
-    public MarkTaskCommand(Index index) {
+    public UnmarkTaskCommand(Index index) {
         requireNonNull(index);
         this.index = index;
     }
@@ -36,10 +36,10 @@ public class MarkTaskCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
-        Task taskToMark = readOnlyTaskList.get(index.getZeroBased());
+        Task taskToUnmark = readOnlyTaskList.get(index.getZeroBased());
 
-        model.markTask(taskToMark);
-        return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, taskToMark));
+        model.unmarkTask(taskToUnmark);
+        return new CommandResult(String.format(MESSAGE_UNMARK_TASK_SUCCESS, taskToUnmark));
     }
 
 }

--- a/src/main/java/seedu/calidr/logic/parser/CalidrParser.java
+++ b/src/main/java/seedu/calidr/logic/parser/CalidrParser.java
@@ -13,7 +13,9 @@ import seedu.calidr.logic.commands.DeleteTaskCommand;
 import seedu.calidr.logic.commands.EditTaskCommand;
 import seedu.calidr.logic.commands.ExitCommand;
 import seedu.calidr.logic.commands.HelpCommand;
+import seedu.calidr.logic.commands.MarkTaskCommand;
 import seedu.calidr.logic.commands.PageCommand;
+import seedu.calidr.logic.commands.UnmarkTaskCommand;
 import seedu.calidr.logic.commands.ViewDateCommand;
 import seedu.calidr.logic.parser.exceptions.ParseException;
 
@@ -52,6 +54,12 @@ public class CalidrParser {
 
         case EditTaskCommand.COMMAND_WORD:
             return new EditTaskCommandParser().parse(arguments);
+
+        case MarkTaskCommand.COMMAND_WORD:
+            return new MarkTaskCommandParser().parse(arguments);
+
+        case UnmarkTaskCommand.COMMAND_WORD:
+            return new UnmarkTaskCommandParser().parse(arguments);
 
         case DeleteTaskCommand.COMMAND_WORD:
             return new DeleteTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/calidr/logic/parser/MarkTaskCommandParser.java
+++ b/src/main/java/seedu/calidr/logic/parser/MarkTaskCommandParser.java
@@ -1,0 +1,26 @@
+package seedu.calidr.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.calidr.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.calidr.commons.core.index.Index;
+import seedu.calidr.logic.commands.MarkTaskCommand;
+import seedu.calidr.logic.parser.exceptions.ParseException;
+
+public class MarkTaskCommandParser implements Parser<MarkTaskCommand> {
+    public MarkTaskCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkTaskCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new MarkTaskCommand(index);
+    }
+}

--- a/src/main/java/seedu/calidr/logic/parser/UnmarkTaskCommandParser.java
+++ b/src/main/java/seedu/calidr/logic/parser/UnmarkTaskCommandParser.java
@@ -1,0 +1,26 @@
+package seedu.calidr.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.calidr.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.calidr.commons.core.index.Index;
+import seedu.calidr.logic.commands.UnmarkTaskCommand;
+import seedu.calidr.logic.parser.exceptions.ParseException;
+
+public class UnmarkTaskCommandParser implements Parser<UnmarkTaskCommand> {
+    public UnmarkTaskCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkTaskCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new UnmarkTaskCommand(index);
+    }
+}

--- a/src/main/java/seedu/calidr/model/Model.java
+++ b/src/main/java/seedu/calidr/model/Model.java
@@ -134,6 +134,10 @@ public interface Model {
      */
     void setTask(Task target, Task editedTask);
 
+    void markTask(Task task);
+
+    void unmarkTask(Task task);
+
     /**
      * Returns an unmodifiable view of the filtered task list
      */

--- a/src/main/java/seedu/calidr/model/ModelManager.java
+++ b/src/main/java/seedu/calidr/model/ModelManager.java
@@ -188,6 +188,16 @@ public class ModelManager implements Model {
         taskList.setTask(target, editedTask);
     }
 
+    @Override
+    public void markTask(Task task) {
+        taskList.markTask(task);
+    }
+
+    @Override
+    public void unmarkTask(Task task) {
+        taskList.unmarkTask(task);
+    }
+
     //=========== Filtered Task List Accessors =============================================================
 
     /**


### PR DESCRIPTION
Closes #61 

# Features of this PR

1. Added `MarkTaskCommand` and `UnmarkTaskCommand` to enable marking and unmarking a task as 'done'.
1. Added `MarkTaskCommandParser` and `UnmarkTaskCommandParser` to parse the index of task entered by the user.
1. Note that the tasks are modified in place unlike `EditTaskCommand`