### PR TITLE
Refactor addition of optional elements

### DIFF
--- a/src/main/java/seedu/calidr/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/calidr/logic/commands/EditTaskCommand.java
@@ -101,7 +101,10 @@ public class EditTaskCommand extends Command {
             Description oldDescription = todoToEdit.getDescription().orElse(null);
             Description updatedDescription = editTodoDescriptor.getDescription().orElse(oldDescription);
 
-            return new ToDo(updatedTitle, updatedDescription, updatedBy);
+            ToDo updatedTodo = new ToDo(updatedTitle, updatedBy);
+            updatedTodo.setDescription(updatedDescription);
+
+            return updatedTodo;
 
         } else if (taskToEdit instanceof Event) {
             Event eventToEdit = (Event) taskToEdit;
@@ -116,7 +119,10 @@ public class EditTaskCommand extends Command {
             Description oldDescription = eventToEdit.getDescription().orElse(null);
             Description updatedDescription = editEventDescriptor.getDescription().orElse(oldDescription);
 
-            return new Event(updatedTitle, updatedDescription, updatedEventTimes);
+            Event updatedEvent = new Event(updatedTitle, updatedEventTimes);
+            updatedEvent.setDescription(updatedDescription);
+
+            return updatedEvent;
 
         } else {
             // error

--- a/src/main/java/seedu/calidr/logic/parser/AddEventCommandParser.java
+++ b/src/main/java/seedu/calidr/logic/parser/AddEventCommandParser.java
@@ -44,7 +44,9 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
             description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         }
 
-        Event event = new Event(title, description, eventDateTimes);
+        Event event = new Event(title, eventDateTimes);
+        event.setDescription(description);
+
         return new AddEventCommand(event);
     }
 

--- a/src/main/java/seedu/calidr/logic/parser/AddTodoCommandParser.java
+++ b/src/main/java/seedu/calidr/logic/parser/AddTodoCommandParser.java
@@ -41,7 +41,9 @@ public class AddTodoCommandParser implements Parser<AddTodoCommand> {
             description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         }
 
-        ToDo todo = new ToDo(title, description, byDateTime);
+        ToDo todo = new ToDo(title, byDateTime);
+        todo.setDescription(description);
+
         return new AddTodoCommand(todo);
     }
 

--- a/src/main/java/seedu/calidr/model/task/Event.java
+++ b/src/main/java/seedu/calidr/model/task/Event.java
@@ -1,6 +1,5 @@
 package seedu.calidr.model.task;
 
-import seedu.calidr.model.task.params.Description;
 import seedu.calidr.model.task.params.EventDateTimes;
 import seedu.calidr.model.task.params.Title;
 
@@ -16,11 +15,10 @@ public class Event extends Task {
      * Creates an Event with the given details.
      *
      * @param title The title of the Event.
-     * @param description The description of the Event
      * @param eventDateTimes The date-times associated with the Event.
      */
-    public Event(Title title, Description description, EventDateTimes eventDateTimes) {
-        super(title, description);
+    public Event(Title title, EventDateTimes eventDateTimes) {
+        super(title);
 
         assert eventDateTimes != null;
         this.eventDateTimes = eventDateTimes;

--- a/src/main/java/seedu/calidr/model/task/Task.java
+++ b/src/main/java/seedu/calidr/model/task/Task.java
@@ -12,7 +12,7 @@ import seedu.calidr.model.task.params.Title;
 public abstract class Task {
 
     private final Title title;
-    private final Description description;
+    private Description description;
     private boolean isDone;
     private Priority priority;
 
@@ -20,13 +20,12 @@ public abstract class Task {
      * Creates a Task object with the given title and MEDIUM priority.
      *
      * @param title The title of the Task.
-     * @param description The description of the Task
      */
-    public Task(Title title, Description description) {
+    public Task(Title title) {
         assert title != null;
 
         this.title = title;
-        this.description = description;
+
         this.isDone = false;
         this.priority = Priority.MEDIUM;
     }
@@ -38,6 +37,10 @@ public abstract class Task {
 
     public Optional<Description> getDescription() {
         return Optional.ofNullable(this.description);
+    }
+
+    public void setDescription(Description description) {
+        this.description = description;
     }
 
     public void mark() {

--- a/src/main/java/seedu/calidr/model/task/ToDo.java
+++ b/src/main/java/seedu/calidr/model/task/ToDo.java
@@ -1,6 +1,5 @@
 package seedu.calidr.model.task;
 
-import seedu.calidr.model.task.params.Description;
 import seedu.calidr.model.task.params.Title;
 import seedu.calidr.model.task.params.TodoDateTime;
 
@@ -16,11 +15,10 @@ public class ToDo extends Task {
      * Creates a ToDo with the given details.
      *
      * @param title The title of the ToDo.
-     * @param description The description of the ToDo.
      * @param by The deadline date-time of the ToDo.
      */
-    public ToDo(Title title, Description description, TodoDateTime by) {
-        super(title, description);
+    public ToDo(Title title, TodoDateTime by) {
+        super(title);
 
         assert by != null;
         this.byDateTime = by;

--- a/src/main/java/seedu/calidr/model/tasklist/TaskList.java
+++ b/src/main/java/seedu/calidr/model/tasklist/TaskList.java
@@ -7,7 +7,6 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.calidr.model.ReadOnlyTaskList;
 import seedu.calidr.model.task.Task;
-import seedu.calidr.model.task.UniqueTaskList;
 import seedu.calidr.model.task.params.Priority;
 
 /**

--- a/src/main/java/seedu/calidr/model/tasklist/UniqueTaskList.java
+++ b/src/main/java/seedu/calidr/model/tasklist/UniqueTaskList.java
@@ -1,4 +1,4 @@
-package seedu.calidr.model.task;
+package seedu.calidr.model.tasklist;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.calidr.commons.util.CollectionUtil.requireAllNonNull;
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.calidr.model.task.Task;
 import seedu.calidr.model.task.exceptions.DuplicateTaskException;
 import seedu.calidr.model.task.exceptions.TaskNotFoundException;
 import seedu.calidr.model.task.params.Priority;
@@ -123,7 +124,7 @@ public class UniqueTaskList implements Iterable<Task> {
         internalList.get(targetIndex).setPriority(priority);
     }
 
-    public void setTasks(seedu.calidr.model.task.UniqueTaskList replacement) {
+    public void setTasks(UniqueTaskList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
     }
@@ -156,8 +157,8 @@ public class UniqueTaskList implements Iterable<Task> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof seedu.calidr.model.task.UniqueTaskList // instanceof handles nulls
-                && internalList.equals(((seedu.calidr.model.task.UniqueTaskList) other).internalList));
+                || (other instanceof UniqueTaskList // instanceof handles nulls
+                && internalList.equals(((UniqueTaskList) other).internalList));
     }
 
     @Override


### PR DESCRIPTION
# Features of this PR

The `Task` class previously required the optional `Description` to be passed in as an argument to create an object.
This method might make it more difficult to add other optional elements (such as `Location`, `Comment`, etc) as the constructor will have to be modified each time a new optional field is added to the design. 

Hence, let's use setter methods to set the values of the optional fields.