### PR TITLE
Event date-time error bug fix

### DIFF
--- a/src/main/java/seedu/calidr/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/calidr/logic/commands/EditTaskCommand.java
@@ -114,11 +114,17 @@ public class EditTaskCommand extends Command {
             EditEventDescriptor editEventDescriptor = new EditEventDescriptor(editTaskDescriptor);
 
             Title updatedTitle = editEventDescriptor.getTitle().orElse(eventToEdit.getTitle());
+
             LocalDateTime updatedFromDateTime = editEventDescriptor.getFromDateTime()
                     .orElse(eventToEdit.getEventDateTimes().from);
             LocalDateTime updatedToDateTime = editEventDescriptor.getToDateTime()
                     .orElse(eventToEdit.getEventDateTimes().to);
+
+            if (!EventDateTimes.isValidEventDateTimes(updatedFromDateTime, updatedToDateTime)) {
+                throw new CommandException(EventDateTimes.MESSAGE_CONSTRAINTS);
+            }
             EventDateTimes updatedEventTimes = new EventDateTimes(updatedFromDateTime, updatedToDateTime);
+
             Description oldDescription = eventToEdit.getDescription().orElse(null);
             Description updatedDescription = editEventDescriptor.getDescription().orElse(oldDescription);
             Priority updatedPriority = editEventDescriptor.getPriority().orElse(eventToEdit.getPriority());

--- a/src/main/java/seedu/calidr/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/calidr/logic/parser/ParserUtil.java
@@ -264,6 +264,10 @@ public class ParserUtil {
         LocalDateTime from = parseDateTime(fromDateTime);
         LocalDateTime to = parseDateTime(toDateTime);
 
+        if (!EventDateTimes.isValidEventDateTimes(from, to)) {
+            throw new ParseException(EventDateTimes.MESSAGE_CONSTRAINTS);
+        }
+
         return new EventDateTimes(from, to);
     }
 

--- a/src/main/java/seedu/calidr/model/task/params/EventDateTimes.java
+++ b/src/main/java/seedu/calidr/model/task/params/EventDateTimes.java
@@ -38,7 +38,7 @@ public class EventDateTimes {
      * Returns true if a particular set of START and END date-times
      * is valid.
      */
-    public boolean isValidEventDateTimes(LocalDateTime start, LocalDateTime end) {
+    public static boolean isValidEventDateTimes(LocalDateTime start, LocalDateTime end) {
         return end.isAfter(start);
     }
 


### PR DESCRIPTION
## Features of this PR

1. Fixed bugs in handling cases when _invalid_ start and end date-times (when the end date-time is before the start date-time) are given for an `Event` either while adding or editing.
   - Previously, an `IllegalArgumentException` was thrown and not being caught.