### PR TITLE
New feature - Search for Tasks

### DIFF
--- a/src/main/java/seedu/calidr/logic/commands/SearchTaskCommand.java
+++ b/src/main/java/seedu/calidr/logic/commands/SearchTaskCommand.java
@@ -1,0 +1,43 @@
+package seedu.calidr.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.calidr.commons.core.Messages;
+import seedu.calidr.model.Model;
+import seedu.calidr.model.task.predicates.TitleContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all tasks whose title contains any of the
+ * keywords given. Keyword matching is case-insensitive.
+ */
+public class SearchTaskCommand extends Command {
+    public static final String COMMAND_WORD = "search";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all tasks whose titles contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " assignment homework";
+
+    private final TitleContainsKeywordsPredicate predicate;
+
+    public SearchTaskCommand(TitleContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        model.updateFilteredTaskList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW,
+                        model.getFilteredTaskList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SearchTaskCommand // instanceof handles nulls
+                && predicate.equals(((SearchTaskCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/calidr/logic/parser/CalidrParser.java
+++ b/src/main/java/seedu/calidr/logic/parser/CalidrParser.java
@@ -15,6 +15,7 @@ import seedu.calidr.logic.commands.ExitCommand;
 import seedu.calidr.logic.commands.HelpCommand;
 import seedu.calidr.logic.commands.MarkTaskCommand;
 import seedu.calidr.logic.commands.PageCommand;
+import seedu.calidr.logic.commands.SearchTaskCommand;
 import seedu.calidr.logic.commands.ShowCommand;
 import seedu.calidr.logic.commands.UnmarkTaskCommand;
 import seedu.calidr.logic.commands.ViewDateCommand;
@@ -73,6 +74,9 @@ public class CalidrParser {
 
         case ShowCommand.COMMAND_WORD:
             return new ShowCommandParser().parse(arguments);
+
+        case SearchTaskCommand.COMMAND_WORD:
+            return new SearchTaskCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/calidr/logic/parser/SearchTaskCommandParser.java
+++ b/src/main/java/seedu/calidr/logic/parser/SearchTaskCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.calidr.logic.parser;
+
+import static seedu.calidr.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.calidr.logic.commands.SearchTaskCommand;
+import seedu.calidr.logic.parser.exceptions.ParseException;
+import seedu.calidr.model.task.predicates.TitleContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new SearchTaskCommand object
+ */
+public class SearchTaskCommandParser implements Parser<SearchTaskCommand>{
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SearchTaskCommand
+     * and returns a SearchTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SearchTaskCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchTaskCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new SearchTaskCommand(new TitleContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+}

--- a/src/main/java/seedu/calidr/logic/parser/SearchTaskCommandParser.java
+++ b/src/main/java/seedu/calidr/logic/parser/SearchTaskCommandParser.java
@@ -11,7 +11,7 @@ import seedu.calidr.model.task.predicates.TitleContainsKeywordsPredicate;
 /**
  * Parses input arguments and creates a new SearchTaskCommand object
  */
-public class SearchTaskCommandParser implements Parser<SearchTaskCommand>{
+public class SearchTaskCommandParser implements Parser<SearchTaskCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the SearchTaskCommand

--- a/src/main/java/seedu/calidr/model/task/predicates/TitleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/calidr/model/task/predicates/TitleContainsKeywordsPredicate.java
@@ -1,0 +1,33 @@
+package seedu.calidr.model.task.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.calidr.model.task.Task;
+
+/**
+ * Tests that a {@code Task}'s {@code Title} contains any of the keywords given.
+ */
+public class TitleContainsKeywordsPredicate implements Predicate<Task> {
+
+    private final List<String> keywords;
+
+    public TitleContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Task task) {
+        return keywords.stream()
+                .anyMatch(keyword -> task.getTitle().value.toLowerCase().contains(keyword.toLowerCase()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TitleContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TitleContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+
+}

--- a/src/main/java/seedu/calidr/model/task/predicates/TitleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/calidr/model/task/predicates/TitleContainsKeywordsPredicate.java
@@ -18,8 +18,9 @@ public class TitleContainsKeywordsPredicate implements Predicate<Task> {
 
     @Override
     public boolean test(Task task) {
+        String titleValue = task.getTitle().value.toLowerCase();
         return keywords.stream()
-                .anyMatch(keyword -> task.getTitle().value.toLowerCase().contains(keyword.toLowerCase()));
+                .anyMatch(keyword -> titleValue.contains(keyword.toLowerCase()));
     }
 
     @Override


### PR DESCRIPTION
Closes #62

The user can now search for a `Task` by entering keywords.

Tasks whose titles contain any of the given keywords (keyword matching is case-insensitive) will be shown to the user in a list.